### PR TITLE
Fix equality check in findPitStopServerInRegistry method

### DIFF
--- a/pitstop-server-cli.js
+++ b/pitstop-server-cli.js
@@ -72,7 +72,7 @@ var PitStopServer = /** @class */ (function () {
          */
         this.run = function () { return __awaiter(_this, void 0, void 0, function () {
             var execResult;
-            return __generator(this, function (_a) {
+            return __generator(this, function (_b) {
                 //add the input file, output folder and the profile and action lists, the report types, and the variable set to the config file
                 try {
                     this.updateConfigFile();
@@ -172,7 +172,7 @@ var PitStopServer = /** @class */ (function () {
                 }
             };
             try {
-                fs.writeFileSync(_this.finalVariableSetPath, jstoxml_1.toXML(evs, xmlOptions));
+                fs.writeFileSync(_this.finalVariableSetPath, (0, jstoxml_1.toXML)(evs, xmlOptions));
             }
             catch (err) {
                 throw err;
@@ -592,6 +592,8 @@ var PitStopServer = /** @class */ (function () {
             }
         }
     }
+    var _a;
+    _a = PitStopServer;
     //////////////////////////////////////////////////////////////////////////
     //
     // PitStopServer static API methods
@@ -603,8 +605,8 @@ var PitStopServer = /** @class */ (function () {
      */
     PitStopServer.getVersion = function () { return __awaiter(void 0, void 0, void 0, function () {
         var execResult, error_1;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
+        return __generator(_a, function (_b) {
+            switch (_b.label) {
                 case 0:
                     //get the application path of PitStop Server
                     if (PitStopServer.applicationPath == undefined) {
@@ -615,15 +617,15 @@ var PitStopServer = /** @class */ (function () {
                             throw error;
                         }
                     }
-                    _a.label = 1;
+                    _b.label = 1;
                 case 1:
-                    _a.trys.push([1, 3, , 4]);
+                    _b.trys.push([1, 3, , 4]);
                     return [4 /*yield*/, execa(PitStopServer.applicationPath, ["-version"])];
                 case 2:
-                    execResult = _a.sent();
+                    execResult = _b.sent();
                     return [2 /*return*/, execResult.stdout];
                 case 3:
-                    error_1 = _a.sent();
+                    error_1 = _b.sent();
                     throw error_1;
                 case 4: return [2 /*return*/];
             }
@@ -688,8 +690,9 @@ var PitStopServer = /** @class */ (function () {
         }
         var applicationPath = "";
         for (var i = 0; i < values.length; i++) {
-            if ((values[i].name = "Path")) {
+            if ((values[i].name == "Path")) {
                 applicationPath = values[i].data;
+                break;
             }
         }
         if (applicationPath == "") {

--- a/pitstop-server-cli.ts
+++ b/pitstop-server-cli.ts
@@ -112,45 +112,45 @@ export class PitStopServer {
           this.inputPDF = options.inputPDF;
           break;
         case "outputPDFName":
-          this.outputPDFName = options.outputPDFName;
+          this.outputPDFName = options.outputPDFName!;
         case "outputFolder":
           this.outputFolder = options.outputFolder;
           break;
         case "preflightProfile":
-          this.preflightProfile = options.preflightProfile;
+          this.preflightProfile = options.preflightProfile!;
           break;
         case "actionLists":
-          this.actionLists = options.actionLists;
+          this.actionLists = options.actionLists!;
           break;
         case "variableSet":
-          this.variableSet = options.variableSet;
+          this.variableSet = options.variableSet!;
           break;
         case "pdfReport":
-          this.pdfReport = options.pdfReport;
+          this.pdfReport = options.pdfReport!;
           break;
         case "pdfReportName":
-          this.pdfReportName = options.pdfReportName;
+          this.pdfReportName = options.pdfReportName!;
           break;
         case "xmlReport":
-          this.xmlReport = options.xmlReport;
+          this.xmlReport = options.xmlReport!;
           break;
         case "xmlReportName":
-          this.xmlReportName = options.xmlReportName;
+          this.xmlReportName = options.xmlReportName!;
           break;
         case "taskReport":
-          this.taskReport = options.taskReport;
+          this.taskReport = options.taskReport!;
           break;
         case "taskReportName":
-          this.taskReportName = options.taskReportName;
+          this.taskReportName = options.taskReportName!;
           break;
         case "configFile":
-          this.configFile = options.configFile;
+          this.configFile = options.configFile!;
           break;
         case "configFileName":
-          this.configFileName = options.configFileName;
+          this.configFileName = options.configFileName!;
           break;
         case "applicationPath":
-          PitStopServer.applicationPath = options.applicationPath;
+          PitStopServer.applicationPath = options.applicationPath!;
           break;
         case "measurementUnit":
           this.measurementUnit = options.measurementUnit;
@@ -262,7 +262,7 @@ export class PitStopServer {
     };
 
     let variableNode: Record<string, any>, variabletype: string;
-    let variableNodes = [];
+    let variableNodes: Array<Record<string, any>> = [];
     for (let i = 0; i < values.length; i++) {
       variableNode = {
         _name: "Variable",
@@ -278,7 +278,7 @@ export class PitStopServer {
     }
 
     let operatorNode;
-    let operatorNodes = [];
+    let operatorNodes: Array<any> = [];
     for (let i = 0; i < values.length; i++) {
       if (values[i].type == "Length") {
         //convert to points based on the measurementUnit
@@ -588,7 +588,7 @@ export class PitStopServer {
           "The configuration file does not contain a node for the measurement unit. The default will be used."
         );
       } else {
-        let measurementUnitText = xml.createTextNode(this.measurementUnit);
+        let measurementUnitText = xml.createTextNode(this.measurementUnit!);
         (measurementUnitNode[0] as any).appendChild(measurementUnitText);
       }
 
@@ -597,7 +597,7 @@ export class PitStopServer {
       if (languageNode.length == 0) {
         this.debugMessages.push("The configuration file does not contain a node for the language. The default will be used.");
       } else {
-        let languageText = xml.createTextNode(this.language);
+        let languageText = xml.createTextNode(this.language!);
         (languageNode[0] as any).appendChild(languageText);
       }
 
@@ -738,8 +738,9 @@ export class PitStopServer {
     }
     let applicationPath = "";
     for (let i = 0; i < values.length; i++) {
-      if ((values[i].name = "Path")) {
+      if ((values[i].name == "Path")) {
         applicationPath = values[i].data;
+        break;
       }
     }
     if (applicationPath == "") {


### PR DESCRIPTION
This PR addresses an issue I found whilst using the library locally, there is an issue with the equality check in findPitStopServerInRegistry and the loop can be broken after setting the applicationPath

```
    for (let i = 0; i < values.length; i++) {
      if ((values[i].name = "Path")) {
        applicationPath = values[i].data;
      }
    }
```
to:
```
    for (let i = 0; i < values.length; i++) {
      if ((values[i].name == "Path")) {
        applicationPath = values[i].data;
        break;
      }
    }
```

As part of this PR I've fixed TypeScript compiler errors due to undefined values 